### PR TITLE
Unit test - more strict format string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-include $(GOROOT)/src/Make.inc
-
-TARG=github.com/nu7hatch/uuid
-GOFILES=uuid.go
-
-include $(GOROOT)/src/Make.pkg

--- a/README
+++ b/README
@@ -14,20 +14,7 @@ Use the `go` tool:
 Usage
 -----
 
-	package main
-
-	import uuid "github.com/nu7hatch/gouuid"
-
-	func main() {
-	    // generating v4
-	    u4, _ := uuid.NewV4()
-	
-	    // generating v5 (or v3...)
-	    u5, _ := uuid.NewV5(uuid.NamespaceURL, "nu7hat.ch")
- 	
-	    // parsing
-	    u, _ := uuid.ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-	}
+See http://godoc.org/github.com/nu7hatch/gouuid for documentation and examples.
 
 Copyright
 ---------

--- a/README
+++ b/README
@@ -7,15 +7,9 @@ and 5 UUIDs as specified in RFC 4122.
 
 Installation
 ------------
-Use the `goinstall` tool:
+Use the `go` tool:
 
-	$ goinstall github.com/nu7hatch/gouuid
-
-... or install it manually:
-
-	$ git clone git://github.com/nu7hatch/gouuid.git
-	$ cd gouuid
-	$ make install
+	$ go get github.com/nu7hatch/gouuid
 
 Usage
 -----

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,33 @@
+package uuid_test
+
+import (
+	"fmt"
+	"github.com/nu7hatch/gouuid"
+)
+
+func ExampleNewV4() {
+	u4, err := uuid.NewV4()
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(u4)
+}
+
+func ExampleNewV5() {
+	u5, err := uuid.NewV5(uuid.NamespaceURL, []byte("nu7hat.ch"))
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(u5)
+}
+
+func ExampleParseHex() {
+	u, err := uuid.ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(u)
+}

--- a/uuid.go
+++ b/uuid.go
@@ -133,25 +133,37 @@ func (u *UUID) setBytesFromHash(hash hash.Hash, ns, name []byte) {
 func (u *UUID) setVariant(v byte) {
 	switch v {
 	case ReservedNCS:
-		u[8] = (u[8] | ReservedNCS) & 0xBF
+		// unset bit 7
+		u[8] &= ^byte(0x80)
 	case ReservedRFC4122:
-		u[8] = (u[8] | ReservedRFC4122) & 0x7F
+		// set bit 7
+		u[8] |= 0x80
+		// unset bit 6
+		u[8] &= ^byte(0x40)
 	case ReservedMicrosoft:
-		u[8] = (u[8] | ReservedMicrosoft) & 0x3F
+		// set bits 6 & 7
+		u[8] |= 0x80 | 0x40
+		// unset bit 5
+		u[8] &= ^byte(0x20)
 	}
 }
 
 // Variant returns the UUID Variant, which determines the internal
 // layout of the UUID. This will be one of the constants: RESERVED_NCS,
 // RFC_4122, RESERVED_MICROSOFT, RESERVED_FUTURE.
+// See rfc4122 section 4.1.1: http://www.ietf.org/rfc/rfc4122.txt
 func (u *UUID) Variant() byte {
-	if u[8] & ReservedNCS == ReservedNCS {
+	if u[8] & 0x80 == 0 {
+		// 0 x x
 		return ReservedNCS
-	} else if u[8] & ReservedRFC4122 == ReservedRFC4122 {
+	} else if u[8] & 0x40 == 0 {
+		// 1 0 x
 		return ReservedRFC4122
-	} else if u[8] & ReservedMicrosoft == ReservedMicrosoft {
+	} else if u[8] & 0x20 == 0 {
+		// 1 1 x
 		return ReservedMicrosoft
-	} 
+	}
+	// 1 1 1
 	return ReservedFuture
 }
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-const format = "^[a-z0-9]{8}-[a-z0-9]{4}-[1-5][a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12}$"
+const format = "^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[1-5][[:xdigit:]]{3}-[89ab][[:xdigit:]]{3}-[[:xdigit:]]{12}$"
 
 func TestParse(t *testing.T) {
 	_, err := Parse([]byte{1,2,3,4,5})


### PR DESCRIPTION
Changes:
- hex digit character class
- more strict rfc4122 compliance for variant (see [Wikipedia](http://en.wikipedia.org/wiki/Universally_unique_identifier#Variants_and_versions)):

> The variant covered by the UUID specification is indicated by the two most significant bits of N being 1 0 (i.e., the hexadecimal N will always be 8, 9, A, or B).

This depends on #6 to be merged in order to pass.
