### PR TITLE
Adds JSON marshalling support

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -14,9 +14,10 @@ import (
 	"fmt"
 	"hash"
 	"regexp"
+	"strings"
 )
 
-// The UUID reserved variants. 
+// The UUID reserved variants.
 const (
 	ReservedNCS       byte = 0x80
 	ReservedRFC4122   byte = 0x40
@@ -169,4 +170,26 @@ func (u *UUID) Version() uint {
 // Returns unparsed version of the generated UUID sequence.
 func (u *UUID) String() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
+}
+
+func (id *UUID) MarshalJSON() ([]byte, error) {
+	// Pack the string representation in quotes
+	return []byte(fmt.Sprintf(`"%v"`, id.String())), nil
+}
+
+func (id *UUID) UnmarshalJSON(b []byte) error {
+	raw := string(b)
+
+	if !strings.HasPrefix(raw, "\"") || !strings.HasSuffix(raw, "\"") {
+		return errors.New(fmt.Sprintf("Invalid UUID in JSON, %v is not a valid JSON string", raw))
+	}
+
+	value := raw[1 : len(raw)-2]
+	parsed, err := ParseHex(value)
+	if err != nil {
+		return err
+	}
+
+	id = parsed
+	return nil
 }

--- a/uuid.go
+++ b/uuid.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"hash"
 	"regexp"
-	"strings"
 )
 
 // The UUID reserved variants.
@@ -172,24 +171,27 @@ func (u *UUID) String() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
 }
 
-func (id *UUID) MarshalJSON() ([]byte, error) {
+// MarshalJSON turns UUID into a json.Marshaller.
+func (id UUID) MarshalJSON() ([]byte, error) {
 	// Pack the string representation in quotes
 	return []byte(fmt.Sprintf(`"%v"`, id.String())), nil
 }
 
-func (id *UUID) UnmarshalJSON(b []byte) error {
-	raw := string(b)
-
-	if !strings.HasPrefix(raw, "\"") || !strings.HasSuffix(raw, "\"") {
-		return errors.New(fmt.Sprintf("Invalid UUID in JSON, %v is not a valid JSON string", raw))
+// UnmarshalJSON turns *UUID into a json.Unmarshaller.
+func (id *UUID) UnmarshalJSON(data []byte) error {
+	// Data is expected to be a json string, like: "819c4ff4-31b4-4519-5d24-3c4a129b8649"
+	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+		return errors.New(fmt.Sprintf("Invalid UUID in JSON, %v is not a valid JSON string", string(data)))
 	}
 
-	value := raw[1 : len(raw)-2]
+	// Grab string value without the surrounding " characters
+	value := string(data[1 : len(data)-1])
 	parsed, err := ParseHex(value)
 	if err != nil {
-		return err
+		return errors.New(fmt.Sprintf("Invalid UUID in JSON, %v: %v", value, err))
 	}
 
-	id = parsed
+	// Dereference pointer value and store parsed
+	*id = *parsed
 	return nil
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -141,3 +141,22 @@ func TestJsonMarshal(t *testing.T) {
 		t.Errorf("Expected json '%v', given '%v'", expected, string(data))
 	}
 }
+
+func TestJsonUnmarshal(t *testing.T) {
+	s := "819c4ff4-31b4-4519-5d24-3c4a129b8649"
+
+	data := []byte("{\"Id\":\"" + s + "\"}")
+	v := struct {
+		Id UUID
+	}{}
+
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		t.Errorf("Unexpected error when unmarshalling: %v", err)
+	}
+
+	if v.Id.String() != s {
+		t.Errorf("Expected '%v', give '%v'", s, v.Id.String())
+	}
+
+}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -6,6 +6,7 @@
 package uuid
 
 import (
+	"encoding/json"
 	"regexp"
 	"testing"
 )
@@ -119,5 +120,24 @@ func TestNewV5(t *testing.T) {
 	u4, _ := NewV5(NamespaceURL, []byte("code.google.com"))
 	if u4.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
+	}
+}
+
+func TestJsonMarshal(t *testing.T) {
+	id, err := ParseHex("819c4ff4-31b4-4519-5d24-3c4a129b8649")
+	if err != nil {
+		t.Fatalf("Unable to parse hard coded UUID value: %v", err)
+	}
+
+	doc := make(map[string]interface{})
+	doc["Id"] = id
+
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Errorf("Error while marshalling to json: %v", err)
+	}
+
+	if expected := "{\"Id\":\"819c4ff4-31b4-4519-5d24-3c4a129b8649\"}"; expected != string(data) {
+		t.Errorf("Expected json '%v', given '%v'", expected, string(data))
 	}
 }


### PR DESCRIPTION
I am using the gouuid library for the identifiers of my objects. These objects get stored in a document store and are exposed in a REST api. Both API and database marshal the object to the JSON format. Currently the `uuid.UUID` does not implement the [`json.Marshaller`](http://golang.org/pkg/encoding/json/#Marshaler) and [`json.Unmarshaller`](http://golang.org/pkg/encoding/json/#Unmarshaler) interface. This pull request changes that.

I have added the `MarshalJSON` and `UnmarshalJSON` to the `uuid.UUID` type, which are covered by tests. The JSON value is a hex string as returned by the `uuid.UUID.String` method.
