### PR TITLE
Implements bracket-balance checks and parse speed improvements.

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -26,6 +26,7 @@ const (
 
 // The following standard UUIDs are for use with NewV3() or NewV5().
 var (
+	hexRegExp = regexp.MustCompile(hexPattern)
 	NamespaceDNS, _  = ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	NamespaceURL, _  = ParseHex("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
 	NamespaceOID, _  = ParseHex("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
@@ -52,8 +53,7 @@ type UUID [16]byte
 //     uuid.ParseHex("urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8")
 //
 func ParseHex(s string) (u *UUID, err error) {
-	re := regexp.MustCompile(hexPattern)
-	md := re.FindStringSubmatch(s)
+	md := hexRegExp.FindStringSubmatch(s)
 	if md == nil {
 		err = errors.New("Invalid UUID string")
 		return

--- a/uuid.go
+++ b/uuid.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"regexp"
+	"strings"
 )
 
 // The UUID reserved variants. 
@@ -22,23 +22,17 @@ const (
 	ReservedRFC4122   byte = 0x40
 	ReservedMicrosoft byte = 0x20
 	ReservedFuture    byte = 0x00
+	urnUuidPrefix	string = "urn:uuid:"
+	dash			byte = byte('-')
 )
 
 // The following standard UUIDs are for use with NewV3() or NewV5().
 var (
-	hexRegExp = regexp.MustCompile(hexPattern)
 	NamespaceDNS, _  = ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	NamespaceURL, _  = ParseHex("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
 	NamespaceOID, _  = ParseHex("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
 	NamespaceX500, _ = ParseHex("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
 )
-
-// Pattern used to parse hex string representation of the UUID.
-// FIXME: do something to consider both brackets at one time,
-// current one allows to parse string with only one opening
-// or closing bracket.
-const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-" +
-	"([1-5][a-z0-9]{3})-([a-z0-9]{4})-([a-z0-9]{12})\\}?$"
 
 // A UUID representation copmliant with specification in
 // RFC 4122 document.
@@ -53,18 +47,51 @@ type UUID [16]byte
 //     uuid.ParseHex("urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8")
 //
 func ParseHex(s string) (u *UUID, err error) {
-	md := hexRegExp.FindStringSubmatch(s)
-	if md == nil {
+	if strings.HasPrefix(s, urnUuidPrefix) {
+		s = s[len(urnUuidPrefix):]
+	}
+	if strings.HasPrefix(s, "{") {
+		if !strings.HasSuffix(s, "}") {
+			err = errors.New("Invalid UUID string has an opening '{' bracket but no closing '}' bracket")
+			return
+		} else if len(s) != 38 {
+			err = errors.New("Invalid UUID string")
+			return
+		}
+		s = s[1:37]
+	} else if strings.HasSuffix(s, "}") {
+		err = errors.New("Invalid UUID string has no opening '{' bracket but does have a closing '}' bracket")
+		return
+	} else if (len(s) != 36) {
 		err = errors.New("Invalid UUID string")
 		return
 	}
-	hash := md[2] + md[3] + md[4] + md[5] + md[6]
-	b, err := hex.DecodeString(hash)
-	if err != nil {
-		return
-	}
+	var a, b byte
+	var half bool
 	u = new(UUID)
-	copy(u[:], b)
+	v := u[0:0]
+	for i, c := range []byte(s) {
+		if (i == 8 || i == 13 || i == 18 || i == 23) {
+			if (c != dash) {
+				return nil, errors.New("Invalid UUID string had an improper character where '-' expected")
+			}
+			continue
+		}
+		switch {
+		case '0' <= c && c <= '9':
+			b = c - '0'
+		case 'a' <= c && c <= 'f':
+			b = c - 'a' + 10
+		default:
+			return nil, hex.InvalidByteError(i)
+		}
+		if half {
+			v = append(v, (a << 4) | b)
+		} else {
+			a = b
+		}
+		half = !half
+	}
 	return
 }
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -57,6 +57,14 @@ func TestParseString(t *testing.T) {
 	if (u3.String() != raw) {
 		t.Errorf("Expected output to match the UUID input without any prefix")
 	}
+	_, err = ParseHex("{" + raw )
+	if err == nil {
+		t.Errorf("Expected error due to unbalanced opening bracket.")
+	}
+	_, err = ParseHex(raw + "}")
+	if err == nil {
+		t.Errorf("Expected error due to unbalanced closing bracket.")
+	}
 }
 
 func TestNewV3(t *testing.T) {

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -42,6 +42,21 @@ func TestParseString(t *testing.T) {
 	if u.String() != base.String() {
 		t.Errorf("Expected parsed UUID to be the same as base, %s != %s", u.String(), base.String())
 	}
+	raw := "6ba7b814-9dad-11d1-80b4-00c04fd430c8"
+	u2, err := ParseHex("{" + raw + "}")
+	if err != nil {
+		t.Errorf("Expected to parse UUID sequence with brackets without problems")
+	}
+	if (u2.String() != raw) {
+		t.Errorf("Expected output to match the UUID input without brackets")
+	}
+	u3, err := ParseHex("urn:uuid:" + raw)
+	if err != nil {
+		t.Errorf("Expected to parse UUID sequence with 'urn:uuid:' prefix without problems")
+	}
+	if (u3.String() != raw) {
+		t.Errorf("Expected output to match the UUID input without any prefix")
+	}
 }
 
 func TestNewV3(t *testing.T) {
@@ -119,5 +134,12 @@ func TestNewV5(t *testing.T) {
 	u4, _ := NewV5(NamespaceURL, []byte("code.google.com"))
 	if u4.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
+	}
+}
+
+func BenchmarkParseHex(b *testing.B) {
+	for i:=0; i < b.N; i++ {
+		u, _ := NewV4()
+		ParseHex(u.String())
 	}
 }


### PR DESCRIPTION
I saw the lone "FIXME" comment and could not resist trying to help.  

The approach I ended up using is a direct search through the input string rather than a more complicated regular expression.  `ParseHex` is now several times faster as a result, and no longer requires the extra array creation and copy that was caused by `hex.DecodeString`.

Using a directly-coded search has also allowed the error messages to become slightly more descriptive.

Tests have been added to confirm the functionality.
