### PR TITLE
Remove pointer requirement

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -6,7 +6,6 @@
 package uuid
 
 import (
-	"bytes"
 	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha1"
@@ -171,22 +170,4 @@ func (u UUID) Version() uint {
 // Returns unparsed version of the generated UUID sequence.
 func (u UUID) String() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
-}
-
-// Returns JSON valid representation of a uuid
-func (u UUID) MarshalJSON() ([]byte, error) {
-	var buffer bytes.Buffer
-	buffer.WriteString("\"")
-	buffer.WriteString(t.String())
-	buffer.WriteString("\"")
-	return []byte(buffer.String()), nil
-}
-
-// Parses a JSON representation of a uuid
-func (u *UUID) UnmarshalJSON(bytes []byte) error {
-	p, err := ParseHex(string(bytes))
-	if err == nil {
-		copy(t[:], p[:])
-	}
-	return err
 }

--- a/uuid.go
+++ b/uuid.go
@@ -6,6 +6,7 @@
 package uuid
 
 import (
+	"bytes"
 	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha1"
@@ -170,4 +171,22 @@ func (u UUID) Version() uint {
 // Returns unparsed version of the generated UUID sequence.
 func (u UUID) String() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
+}
+
+// Returns JSON valid representation of a uuid
+func (u UUID) MarshalJSON() ([]byte, error) {
+	var buffer bytes.Buffer
+	buffer.WriteString("\"")
+	buffer.WriteString(t.String())
+	buffer.WriteString("\"")
+	return []byte(buffer.String()), nil
+}
+
+// Parses a JSON representation of a uuid
+func (u *UUID) UnmarshalJSON(bytes []byte) error {
+	p, err := ParseHex(string(bytes))
+	if err == nil {
+		copy(t[:], p[:])
+	}
+	return err
 }

--- a/uuid.go
+++ b/uuid.go
@@ -16,7 +16,7 @@ import (
 	"regexp"
 )
 
-// The UUID reserved variants. 
+// The UUID reserved variants.
 const (
 	ReservedNCS       byte = 0x80
 	ReservedRFC4122   byte = 0x40
@@ -86,6 +86,7 @@ func NewV3(ns *UUID, name []byte) (u *UUID, err error) {
 		err = errors.New("Invalid namespace UUID")
 		return
 	}
+
 	u = new(UUID)
 	// Set all bits to MD5 hash generated from namespace and name.
 	u.setBytesFromHash(md5.New(), ns[:], name)
@@ -143,7 +144,7 @@ func (u *UUID) setVariant(v byte) {
 // Variant returns the UUID Variant, which determines the internal
 // layout of the UUID. This will be one of the constants: RESERVED_NCS,
 // RFC_4122, RESERVED_MICROSOFT, RESERVED_FUTURE.
-func (u *UUID) Variant() byte {
+func (u UUID) Variant() byte {
 	if u[8]&ReservedNCS == ReservedNCS {
 		return ReservedNCS
 	} else if u[8]&ReservedRFC4122 == ReservedRFC4122 {
@@ -162,11 +163,11 @@ func (u *UUID) setVersion(v byte) {
 
 // Version returns a version number of the algorithm used to
 // generate the UUID sequence.
-func (u *UUID) Version() uint {
+func (u UUID) Version() uint {
 	return uint(u[6] >> 4)
 }
 
 // Returns unparsed version of the generated UUID sequence.
-func (u *UUID) String() string {
+func (u UUID) String() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
 }


### PR DESCRIPTION
Some methods don't actually require that they be called on a pointer to a UUID specifically the methods that only read the array.
