### PR TITLE
Dont compile the regexp for every ParseHex call.

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -39,6 +39,8 @@ var (
 const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-" +
 	"([1-5][a-z0-9]{3})-([a-z0-9]{4})-([a-z0-9]{12})\\}?$"
 
+var re = regexp.MustCompile(hexPattern)
+
 // A UUID representation compliant with specification in
 // RFC 4122 document.
 type UUID [16]byte
@@ -52,7 +54,6 @@ type UUID [16]byte
 //     uuid.ParseHex("urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8")
 //
 func ParseHex(s string) (u *UUID, err error) {
-	re := regexp.MustCompile(hexPattern)
 	md := re.FindStringSubmatch(s)
 	if md == nil {
 		err = errors.New("Invalid UUID string")

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -121,3 +121,15 @@ func TestNewV5(t *testing.T) {
 		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
 	}
 }
+
+func BenchmarkParseHex(b *testing.B) {
+	s := "f3593cff-ee92-40df-4086-87825b523f13"
+	for i := 0; i < b.N; i++ {
+		_, err := ParseHex(s)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	b.ReportAllocs()
+}


### PR DESCRIPTION
The regexp object is threadsafe for use in multiple goroutines
so it can be compiled during program init.

Added a benchmark to test performance.

Before:
BenchmarkParseHex-4   500000         41549 ns/op       21190 B/op        115 allocs/op

After:
BenchmarkParseHex-4  5000000          4332 ns/op         336 B/op          6 allocs/op
