### PR TITLE
Add output lines to the predictable examples, so godoc embeds it.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -21,6 +21,7 @@ func ExampleNewV5() {
 		return
 	}
 	fmt.Println(u5)
+	// Output: 4443f977-ae75-5388-759f-93c0e0300805
 }
 
 func ExampleParseHex() {
@@ -30,4 +31,5 @@ func ExampleParseHex() {
 		return
 	}
 	fmt.Println(u)
+	// Output: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
 }


### PR DESCRIPTION
Pretty minuscule change. Two of the examples have predictable output, so include an `// Output:` line which causes godoc to embed that output in the online examples.

It'd be nice to have the V4 example do the same, but the UUID changes every run of the example and godoc doesn't have a way of specifying dynamic output.
