### PR TITLE
Fixes to properly conform to the UUID standard for version 3, 4 and 5. Also included are improvements to readability and use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # Pure Go UUID implementation
 
 This package provides immutable UUID structs and the functions
-NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+NewV3, NewV4, NewV5, New and Parse() for generating versions 3, 4
 and 5 UUIDs as specified in [RFC 4122](http://www.ietf.org/rfc/rfc4122.txt).
+
+# Recent Changes
+* varient bits and type is now set correctly
+* varient bits and varient type can now be retrieved more efficiently
+* new tests added for variant setting
+* new tests added to confirm proper version setting
+* type UUID now conforms to the BinaryMarshaller and BinaryUnmarshaller interfaces
+* New was added to create a base UUID from a []byte
+* ParseHex was renamed to simply Parse
+* Parse creates a UUID and properly checks the string format
+* NewHex now performs unsafe creation of UUID from a hex string
+* NewV3 and NewV5 now take strings as a namespace name
 
 ## Installation
 

--- a/example_test.go
+++ b/example_test.go
@@ -16,7 +16,7 @@ func ExampleNewV4() {
 }
 
 func ExampleNewV5() {
-	u5, err := gouuid.NewV5(gouuid.NamespaceURL, "nu7hat.ch")
+	u5, err := gouuid.NewV5(gouuid.NamespaceURL, []byte("nu7hat.ch"))
 	if err != nil {
 		fmt.Println("error:", err)
 		return
@@ -25,7 +25,7 @@ func ExampleNewV5() {
 }
 
 func ExampleParseHex() {
-	u, err := gouuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	u, err := gouuid.ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	if err != nil {
 		fmt.Println("error:", err)
 		return

--- a/example_test.go
+++ b/example_test.go
@@ -1,12 +1,13 @@
-package uuid_test
+package gouuid_test
 
 import (
 	"fmt"
 	"github.com/nu7hatch/gouuid"
+
 )
 
 func ExampleNewV4() {
-	u4, err := uuid.NewV4()
+	u4, err := gouuid.NewV4()
 	if err != nil {
 		fmt.Println("error:", err)
 		return
@@ -15,7 +16,7 @@ func ExampleNewV4() {
 }
 
 func ExampleNewV5() {
-	u5, err := uuid.NewV5(uuid.NamespaceURL, []byte("nu7hat.ch"))
+	u5, err := gouuid.NewV5(gouuid.NamespaceURL, "nu7hat.ch")
 	if err != nil {
 		fmt.Println("error:", err)
 		return
@@ -24,7 +25,7 @@ func ExampleNewV5() {
 }
 
 func ExampleParseHex() {
-	u, err := uuid.ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	u, err := gouuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	if err != nil {
 		fmt.Println("error:", err)
 		return

--- a/uuid.go
+++ b/uuid.go
@@ -1,9 +1,9 @@
 // This package provides immutable UUID structs and the functions
-// NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+// NewV3, NewV4, NewV5, New([]byte) and Parse(string) for generating versions 3, 4
 // and 5 UUIDs as specified in RFC 4122.
 //
 // Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
-package uuid
+package gouuid
 
 import (
 	"crypto/md5"
@@ -14,82 +14,163 @@ import (
 	"fmt"
 	"hash"
 	"regexp"
+	"io"
 )
 
-// The UUID reserved variants. 
+// The UUID reserved variants.
 const (
-	ReservedNCS       byte = 0x80
-	ReservedRFC4122   byte = 0x40
-	ReservedMicrosoft byte = 0x20
-	ReservedFuture    byte = 0x00
+	ReservedNCS       byte = 0x00
+	ReservedRFC4122   byte = 0x80
+	ReservedMicrosoft byte = 0xC0
+	ReservedFuture    byte = 0xE0
+)
+
+const (
+	variantIndex = 8
+	versionIndex = 6
+	length       = 16
 )
 
 // The following standard UUIDs are for use with NewV3() or NewV5().
 var (
-	NamespaceDNS, _  = ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-	NamespaceURL, _  = ParseHex("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
-	NamespaceOID, _  = ParseHex("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
-	NamespaceX500, _ = ParseHex("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceDNS, NamespaceURL, NamespaceOID, NamespaceX500 UUID
+	reg *regexp.Regexp
 )
 
 // Pattern used to parse hex string representation of the UUID.
 // FIXME: do something to consider both brackets at one time,
 // current one allows to parse string with only one opening
 // or closing bracket.
-const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-" +
-	"([1-5][a-z0-9]{3})-([a-z0-9]{4})-([a-z0-9]{12})\\}?$"
+const hexPattern = `^(urn\:uuid\:)?\{?(\w{8})-(\w{4})-([1-5]\w{3})-(\w{4})-(\w{12})\}?$`
 
-var re = regexp.MustCompile(hexPattern)
+func init() {
+	NamespaceDNS = newHex("6ba7b8109dad11d180b400c04fd430c8")
+	NamespaceURL = newHex("6ba7b8119dad11d180b400c04fd430c8")
+	NamespaceOID = newHex("6ba7b8129dad11d180b400c04fd430c8")
+	NamespaceX500 = newHex("6ba7b8149dad11d180b400c04fd430c8")
+	reg = regexp.MustCompile(hexPattern)
+}
 
 // A UUID representation compliant with specification in
 // RFC 4122 document.
-type UUID [16]byte
+type UUID [length]byte
 
-// ParseHex creates a UUID object from given hex string
-// representation. Function accepts UUID string in following
-// formats:
-//
-//     uuid.ParseHex("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
-//     uuid.ParseHex("{6ba7b814-9dad-11d1-80b4-00c04fd430c8}")
-//     uuid.ParseHex("urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8")
-//
-func ParseHex(s string) (u *UUID, err error) {
-	md := re.FindStringSubmatch(s)
-	if md == nil {
-		err = errors.New("Invalid UUID string")
+// Set the three most significant bits (bits 0, 1 and 2) of the
+// clock_seq_hi_and_reserved to variant mask v.
+func (u *UUID) setVariant(v byte) {
+	switch v {
+	case ReservedRFC4122:
+		u[variantIndex] &= 0x3F
+	case ReservedFuture, ReservedMicrosoft:
+		u[variantIndex] &= 0x1F
+	case ReservedNCS:
+		u[variantIndex] &= 0x7F
+	default:
+		panic(errors.New("UUID.setVariant: invalid variant mask"))
+	}
+	u[variantIndex] |= v
+}
+
+// Variant returns the UUID Variant, which determines the internal
+// layout of the UUID. This will be one of the constants: RESERVED_NCS,
+// RFC_4122, RESERVED_MICROSOFT, RESERVED_FUTURE.
+func (u *UUID) Variant() byte {
+	switch u[variantIndex] & 0xE0 {
+	case ReservedRFC4122, 0xA0:
+		return ReservedRFC4122
+	case ReservedMicrosoft:
+		return ReservedMicrosoft
+	case ReservedFuture:
+		return ReservedFuture
+	}
+	return ReservedNCS
+}
+
+// Set the four most significant bits (bits 0 through 3) of the
+// time_hi_and_version field to the 4-bit version number.
+func (u *UUID) setVersion(v byte) {
+	u[versionIndex] &= 0x0F
+	u[versionIndex] |= v<<4
+}
+
+// Version returns a version number of the algorithm used to
+// generate the UUID sequence.
+func (u *UUID) Version() int {
+	return int(u[versionIndex]>>4)
+}
+
+// Returns unparsed version of the generated UUID sequence.
+func (u *UUID) String() string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
+}
+
+// UnmarshalBinary copies data into an existing UUID.
+// This conforms to the BinaryUnmarshaller interface
+func (u *UUID) UnmarshalBinary(data []byte) (err error) {
+	if len(data) != length {
+		err = errors.New("UUID.UnmarshalBinary: data invalid length")
 		return
 	}
-	hash := md[2] + md[3] + md[4] + md[5] + md[6]
-	b, err := hex.DecodeString(hash)
-	if err != nil {
-		return
-	}
-	u = new(UUID)
-	copy(u[:], b)
+	copy(u[:], data)
 	return
 }
 
-// Parse creates a UUID object from given bytes slice.
-func Parse(b []byte) (u *UUID, err error) {
-	if len(b) != 16 {
-		err = errors.New("Given slice is not valid UUID sequence")
+// MarshalBinary returns a slice of UUID array
+// This conforms to the BinaryMarshaller interface
+func (u *UUID) MarshalBinary() (data []byte, err error) {
+	return u[:], nil
+}
+
+// Parse creates a UUID object from given hex string
+// representation. Function accepts UUID string in following
+// formats:
+//
+//     gouuid.Parse("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+//     gouuid.Parse("{6ba7b814-9dad-11d1-80b4-00c04fd430c8}")
+//     gouuid.Parse("urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+//
+func Parse(s string) (u *UUID, err error) {
+	md := reg.FindStringSubmatch(s)
+	if md == nil {
+		err = errors.New("Parse: invalid UUID string")
 		return
 	}
+	return NewHex(md[2] + md[3] + md[4] + md[5] + md[6])
+}
+
+// Unsafe does not check string format
+func NewHex(uuid string) (u *UUID, err error) {
+	bytes, err := hex.DecodeString(uuid)
+	if err != nil {
+		return
+	}
+	return New(bytes)
+}
+
+// Unsafe does not check string format
+func newHex(uuid string) UUID {
+	u, err := NewHex(uuid)
+	if err != nil {
+		panic(err)
+	}
+	return *u
+}
+
+// New creates a UUID object from data byte slice.
+func New(data []byte) (u *UUID, err error) {
 	u = new(UUID)
-	copy(u[:], b)
+	err = u.UnmarshalBinary(data)
 	return
 }
 
 // Generate a UUID based on the MD5 hash of a namespace identifier
 // and a name.
-func NewV3(ns *UUID, name []byte) (u *UUID, err error) {
-	if ns == nil {
-		err = errors.New("Invalid namespace UUID")
+func NewV3(ns UUID, name string) (u *UUID, err error) {
+	// Set all bits to MD5 hash generated from namespace and name.
+	u, err = New(sum(md5.New(), ns, name))
+	if err != nil {
 		return
 	}
-	u = new(UUID)
-	// Set all bits to MD5 hash generated from namespace and name.
-	u.setBytesFromHash(md5.New(), ns[:], name)
 	u.setVariant(ReservedRFC4122)
 	u.setVersion(3)
 	return
@@ -99,9 +180,9 @@ func NewV3(ns *UUID, name []byte) (u *UUID, err error) {
 func NewV4() (u *UUID, err error) {
 	u = new(UUID)
 	// Set all bits to randomly (or pseudo-randomly) chosen values.
-	_, err = rand.Read(u[:])
+	_, err = rand.Read(u[:length]) // explicit length to ensure proper slice
 	if err != nil {
-		return
+		panic(err)
 	}
 	u.setVariant(ReservedRFC4122)
 	u.setVersion(4)
@@ -110,64 +191,22 @@ func NewV4() (u *UUID, err error) {
 
 // Generate a UUID based on the SHA-1 hash of a namespace identifier
 // and a name.
-func NewV5(ns *UUID, name []byte) (u *UUID, err error) {
-	u = new(UUID)
+func NewV5(ns UUID, name string) (u *UUID, err error) {
 	// Set all bits to truncated SHA1 hash generated from namespace
 	// and name.
-	u.setBytesFromHash(sha1.New(), ns[:], name)
+	u, err = New(sum(sha1.New(), ns, name))
+	if err != nil {
+		return
+	}
 	u.setVariant(ReservedRFC4122)
 	u.setVersion(5)
 	return
 }
 
-// Generate a MD5 hash of a namespace and a name, and copy it to the
+// Generate a check sum hash of a namespace and a name, and copy it to the
 // UUID slice.
-func (u *UUID) setBytesFromHash(hash hash.Hash, ns, name []byte) {
-	hash.Write(ns[:])
-	hash.Write(name)
-	copy(u[:], hash.Sum([]byte{})[:16])
-}
-
-// Set the two most significant bits (bits 6 and 7) of the
-// clock_seq_hi_and_reserved to zero and one, respectively.
-func (u *UUID) setVariant(v byte) {
-	switch v {
-	case ReservedNCS:
-		u[8] = (u[8] | ReservedNCS) & 0xBF
-	case ReservedRFC4122:
-		u[8] = (u[8] | ReservedRFC4122) & 0x7F
-	case ReservedMicrosoft:
-		u[8] = (u[8] | ReservedMicrosoft) & 0x3F
-	}
-}
-
-// Variant returns the UUID Variant, which determines the internal
-// layout of the UUID. This will be one of the constants: RESERVED_NCS,
-// RFC_4122, RESERVED_MICROSOFT, RESERVED_FUTURE.
-func (u *UUID) Variant() byte {
-	if u[8]&ReservedNCS == ReservedNCS {
-		return ReservedNCS
-	} else if u[8]&ReservedRFC4122 == ReservedRFC4122 {
-		return ReservedRFC4122
-	} else if u[8]&ReservedMicrosoft == ReservedMicrosoft {
-		return ReservedMicrosoft
-	}
-	return ReservedFuture
-}
-
-// Set the four most significant bits (bits 12 through 15) of the
-// time_hi_and_version field to the 4-bit version number.
-func (u *UUID) setVersion(v byte) {
-	u[6] = (u[6] & 0xF) | (v << 4)
-}
-
-// Version returns a version number of the algorithm used to
-// generate the UUID sequence.
-func (u *UUID) Version() uint {
-	return uint(u[6] >> 4)
-}
-
-// Returns unparsed version of the generated UUID sequence.
-func (u *UUID) String() string {
-	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
+func sum(h hash.Hash, ns UUID, name string) []byte {
+	h.Write(ns[:])
+	io.WriteString(h, name)
+	return h.Sum(nil)[:length]
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -3,32 +3,121 @@
 // and 5 UUIDs as specified in RFC 4122.
 //
 // Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
-package uuid
+package gouuid
 
 import (
 	"regexp"
 	"testing"
+	"fmt"
 )
 
 const format = "^[a-z0-9]{8}-[a-z0-9]{4}-[1-5][a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12}$"
 
-func TestParse(t *testing.T) {
-	_, err := Parse([]byte{1, 2, 3, 4, 5})
-	if err == nil {
-		t.Errorf("Expected error due to invalid UUID sequence")
+var (
+	uuidBytes    = []byte{
+	0xAA, 0xCF, 0xEE, 0x12,
+	0xD4, 0x00,
+	0x67, 0x23,
+	0x00,
+	0xD3,
+	0x23, 0x12, 0x4A, 0x11, 0x89, 0xFF,
+}
+	uuidVariants = []byte{
+	ReservedNCS, ReservedRFC4122, ReservedMicrosoft, ReservedFuture,
+}
+	printer      = false
+)
+
+func TestVarientBits(t *testing.T) {
+
+	u := new(UUID)
+	for _, v := range uuidVariants {
+		for i := 0; i <= 255; i ++ {
+			uuidBytes[variantIndex] = byte(i)
+			copy(u[:], uuidBytes)
+			u.setVariant(v)
+			b := u[variantIndex]>>4
+			t_VariantConstraint(v, b, u, t)
+			if u.Variant() != v {
+				t.Errorf("%d does not resolve to %x", i, v)
+			}
+		}
 	}
-	base, _ := NewV4()
-	u, err := Parse(base[:])
+}
+
+func t_VariantConstraint(v, b byte, u *UUID, t *testing.T) {
+	output(u)
+	switch v {
+	case ReservedNCS:
+		switch b {
+		case 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07:
+			outputf(": %X ", b)
+			break
+		default: t.Errorf("%X most high bits do not resolve to 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07", b)
+		}
+	case ReservedRFC4122:
+		switch b {
+		case 0x08, 0x09, 0x0A, 0x0B:
+			outputf(": %X ", b)
+			break
+		default: t.Errorf("%X most high bits do not resolve to 0x08, 0x09, 0x0A, 0x0B", b)
+		}
+	case ReservedMicrosoft:
+		switch b {
+		case 0x0C, 0x0D:
+			outputf(": %X ", b)
+			break
+		default: t.Errorf("%X most high bits do not resolve to 0x0C, 0x0D", b)
+		}
+	case ReservedFuture:
+		switch b {
+		case 0x0E, 0x0F:
+			outputf(": %X ", b)
+			break
+		default: t.Errorf("%X most high bits do not resolve to 0x0E, 0x0F", b)
+		}
+	}
+	output("\n")
+}
+
+func TestUnmarshalBinary(t *testing.T) {
+	u := new(UUID)
+	err := u.UnmarshalBinary([]byte{1, 2, 3, 4, 5})
+	if err == nil {
+		t.Errorf("Expected error due to invalid bte length")
+	}
+
+	err = u.UnmarshalBinary(uuidBytes)
 	if err != nil {
 		t.Errorf("Expected to parse UUID sequence without problems")
 		return
 	}
-	if u.String() != base.String() {
-		t.Errorf("Expected parsed UUID to be the same as base, %s != %s", u.String(), base.String())
+	if u.String() != u.String() {
+		t.Errorf("Expected parsed UUID to be the same as base, %s != %s", u.String(), u.String())
 	}
 }
 
-func TestParseString(t *testing.T) {
+func TestUUID_VersionBits(t *testing.T) {
+	u := new(UUID)
+	for v := 0; v < 16; v++ {
+		for i := 0; i <= 255; i ++ {
+			uuidBytes[versionIndex] = byte(i)
+			t_VersionConstraints(v, u, t)
+		}
+	}
+}
+
+func t_VersionConstraints(v int, u *UUID, t *testing.T) {
+	copy(u[:], uuidBytes)
+	u.setVersion(byte(v))
+	output(u)
+	if u.Version() != v {
+		t.Errorf("%x does not resolve to %x", byte(u.Version()), v)
+	}
+	output("\n")
+}
+
+func TestUUID_ParseString(t *testing.T) {
 	_, err := ParseHex("foo")
 	if err == nil {
 		t.Errorf("Expected error due to invalid UUID string")
@@ -44,8 +133,51 @@ func TestParseString(t *testing.T) {
 	}
 }
 
+var (
+	invalidHexStrings = [...]string{
+	"foo",
+	"6ba7b814-9dad-11d1-80b4-",
+	"6ba7b8149dad-11d1-80b4-00c04fd430c8",
+	"6ba7b814-9dad11d1-80b4-00c04fd430c8",
+	"6ba7b814-9dad-11d180b4-00c04fd430c8",
+	"6ba7b814-9dad-11d1-80b400c04fd430c8",
+	"6ba7b8149dad11d180b400c04fd430c8",
+	"6ba7b8147-9dad11d1-80b400c04fd430c8",
+	"6ba7b814--9dad-11d1-80b4--00c04fd430c8",
+	"6ba7b814-9dad7-11d1-80b4-00c04fd430c8999",
+	"{6ba7b814-9dad-1180b4-00c04fd430c8",
+	"{6ba7b814--11d1-80b4-00c04fd430c8}",
+	"6ba7b8149dad-11d1-80b4-00c04fd430c8}",
+	"{6ba7b8149dad-11d1-80b400c04fd430c8}",
+	"{6ba7b814-9dad11d180b400c04fd430c8}",
+	"urn:uuid:6ba7b814-9dad-1666666680b4-00c04fd430c8",
+}
+	validHexStrings    = [...]string{
+	"6ba7b814-9dad-11d1-80b4-00c04fd430c8",
+	"{6ba7b814-9dad-11d1-80b4-00c04fd430c8}",
+	"{6ba7b814-9dad-11d1-80b4-00c04fd430c8",
+	"6ba7b814-9dad-11d1-80b4-00c04fd430c8}",
+	"urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8",
+}
+)
+
+func TestUUID_ParseHex(t *testing.T) {
+	for _, v := range invalidHexStrings {
+		_, err := ParseHex(v)
+		if err == nil {
+			t.Errorf("Expected error due to invalid UUID string %s", v)
+		}
+	}
+	for _, v := range validHexStrings {
+		_, err := ParseHex(v)
+		if err != nil {
+			t.Errorf("Expected valid UUID string %s but got error", v)
+		}
+	}
+}
+
 func TestNewV3(t *testing.T) {
-	u, err := NewV3(NamespaceURL, []byte("golang.org"))
+	u, err := NewV3(NamespaceURL, "golang.org")
 	if err != nil {
 		t.Errorf("Expected to generate UUID without problems, error thrown: %d", err.Error())
 		return
@@ -60,15 +192,15 @@ func TestNewV3(t *testing.T) {
 	if !re.MatchString(u.String()) {
 		t.Errorf("Expected string representation to be valid, given %s", u.String())
 	}
-	u2, _ := NewV3(NamespaceURL, []byte("golang.org"))
+	u2, _ := NewV3(NamespaceURL, "golang.org")
 	if u2.String() != u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and name to be the same")
 	}
-	u3, _ := NewV3(NamespaceDNS, []byte("golang.org"))
+	u3, _ := NewV3(NamespaceDNS, "golang.org")
 	if u3.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of different namespace and the same name to be different")
 	}
-	u4, _ := NewV3(NamespaceURL, []byte("code.google.com"))
+	u4, _ := NewV3(NamespaceURL, "code.google.com")
 	if u4.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
 	}
@@ -93,7 +225,7 @@ func TestNewV4(t *testing.T) {
 }
 
 func TestNewV5(t *testing.T) {
-	u, err := NewV5(NamespaceURL, []byte("golang.org"))
+	u, err := NewV5(NamespaceURL, "golang.org")
 	if err != nil {
 		t.Errorf("Expected to generate UUID without problems, error thrown: %d", err.Error())
 		return
@@ -108,15 +240,15 @@ func TestNewV5(t *testing.T) {
 	if !re.MatchString(u.String()) {
 		t.Errorf("Expected string representation to be valid, given %s", u.String())
 	}
-	u2, _ := NewV5(NamespaceURL, []byte("golang.org"))
+	u2, _ := NewV5(NamespaceURL, "golang.org")
 	if u2.String() != u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and name to be the same")
 	}
-	u3, _ := NewV5(NamespaceDNS, []byte("golang.org"))
+	u3, _ := NewV5(NamespaceDNS, "golang.org")
 	if u3.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of different namespace and the same name to be different")
 	}
-	u4, _ := NewV5(NamespaceURL, []byte("code.google.com"))
+	u4, _ := NewV5(NamespaceURL, "code.google.com")
 	if u4.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
 	}
@@ -132,4 +264,16 @@ func BenchmarkParseHex(b *testing.B) {
 	}
 	b.StopTimer()
 	b.ReportAllocs()
+}
+
+func output(a interface{}) {
+	if printer {
+		fmt.Print(a)
+	}
+}
+
+func outputf(format string, a... interface{}) {
+	if printer {
+		fmt.Printf(format, a)
+	}
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,5 +1,5 @@
 // This package provides immutable UUID structs and the functions
-// NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+// NewV3, NewV4, NewV5 and ParseHex() for generating versions 3, 4
 // and 5 UUIDs as specified in RFC 4122.
 //
 // Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
@@ -117,13 +117,13 @@ func t_VersionConstraints(v int, u *UUID, t *testing.T) {
 	output("\n")
 }
 
-func TestUUID_ParseString(t *testing.T) {
-	_, err := Parse("foo")
+func TestUUID_ParseHexString(t *testing.T) {
+	_, err := ParseHex("foo")
 	if err == nil {
 		t.Errorf("Expected error due to invalid UUID string")
 	}
 	base, _ := NewV4()
-	u, err := Parse(base.String())
+	u, err := ParseHex(base.String())
 	if err != nil {
 		t.Errorf("Expected to parse UUID sequence without problems")
 		return
@@ -161,15 +161,15 @@ var (
 }
 )
 
-func TestUUID_Parse(t *testing.T) {
+func TestUUID_ParseHex(t *testing.T) {
 	for _, v := range invalidHexStrings {
-		_, err := Parse(v)
+		_, err := ParseHex(v)
 		if err == nil {
 			t.Errorf("Expected error due to invalid UUID string %s", v)
 		}
 	}
 	for _, v := range validHexStrings {
-		_, err := Parse(v)
+		_, err := ParseHex(v)
 		if err != nil {
 			t.Errorf("Expected valid UUID string %s but got error", v)
 		}
@@ -177,7 +177,7 @@ func TestUUID_Parse(t *testing.T) {
 }
 
 func TestNewV3(t *testing.T) {
-	u, err := NewV3(NamespaceURL, "golang.org")
+	u, err := NewV3(NamespaceURL, []byte("golang.org"))
 	if err != nil {
 		t.Errorf("Expected to generate UUID without problems, error thrown: %d", err.Error())
 		return
@@ -192,15 +192,15 @@ func TestNewV3(t *testing.T) {
 	if !re.MatchString(u.String()) {
 		t.Errorf("Expected string representation to be valid, given %s", u.String())
 	}
-	u2, _ := NewV3(NamespaceURL, "golang.org")
+	u2, _ := NewV3(NamespaceURL, []byte("golang.org"))
 	if u2.String() != u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and name to be the same")
 	}
-	u3, _ := NewV3(NamespaceDNS, "golang.org")
+	u3, _ := NewV3(NamespaceDNS, []byte("golang.org")  )
 	if u3.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of different namespace and the same name to be different")
 	}
-	u4, _ := NewV3(NamespaceURL, "code.google.com")
+	u4, _ := NewV3(NamespaceURL, []byte("code.google.com") )
 	if u4.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
 	}
@@ -225,7 +225,7 @@ func TestNewV4(t *testing.T) {
 }
 
 func TestNewV5(t *testing.T) {
-	u, err := NewV5(NamespaceURL, "golang.org")
+	u, err := NewV5(NamespaceURL, []byte("golang.org"))
 	if err != nil {
 		t.Errorf("Expected to generate UUID without problems, error thrown: %d", err.Error())
 		return
@@ -240,24 +240,24 @@ func TestNewV5(t *testing.T) {
 	if !re.MatchString(u.String()) {
 		t.Errorf("Expected string representation to be valid, given %s", u.String())
 	}
-	u2, _ := NewV5(NamespaceURL, "golang.org")
+	u2, _ := NewV5(NamespaceURL, []byte("golang.org"))
 	if u2.String() != u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and name to be the same")
 	}
-	u3, _ := NewV5(NamespaceDNS, "golang.org")
+	u3, _ := NewV5(NamespaceDNS, []byte("golang.org"))
 	if u3.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of different namespace and the same name to be different")
 	}
-	u4, _ := NewV5(NamespaceURL, "code.google.com")
+	u4, _ := NewV5(NamespaceURL, []byte("code.google.com"))
 	if u4.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
 	}
 }
 
-func BenchmarkParseHex(b *testing.B) {
+func BenchmarkParseHexHex(b *testing.B) {
 	s := "f3593cff-ee92-40df-4086-87825b523f13"
 	for i := 0; i < b.N; i++ {
-		_, err := Parse(s)
+		_, err := ParseHex(s)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -118,12 +118,12 @@ func t_VersionConstraints(v int, u *UUID, t *testing.T) {
 }
 
 func TestUUID_ParseString(t *testing.T) {
-	_, err := ParseHex("foo")
+	_, err := Parse("foo")
 	if err == nil {
 		t.Errorf("Expected error due to invalid UUID string")
 	}
 	base, _ := NewV4()
-	u, err := ParseHex(base.String())
+	u, err := Parse(base.String())
 	if err != nil {
 		t.Errorf("Expected to parse UUID sequence without problems")
 		return
@@ -161,15 +161,15 @@ var (
 }
 )
 
-func TestUUID_ParseHex(t *testing.T) {
+func TestUUID_Parse(t *testing.T) {
 	for _, v := range invalidHexStrings {
-		_, err := ParseHex(v)
+		_, err := Parse(v)
 		if err == nil {
 			t.Errorf("Expected error due to invalid UUID string %s", v)
 		}
 	}
 	for _, v := range validHexStrings {
-		_, err := ParseHex(v)
+		_, err := Parse(v)
 		if err != nil {
 			t.Errorf("Expected valid UUID string %s but got error", v)
 		}
@@ -257,7 +257,7 @@ func TestNewV5(t *testing.T) {
 func BenchmarkParseHex(b *testing.B) {
 	s := "f3593cff-ee92-40df-4086-87825b523f13"
 	for i := 0; i < b.N; i++ {
-		_, err := ParseHex(s)
+		_, err := Parse(s)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
- varient bits and type is now set correctly
- varient bits and varient type can now be retrieved more efficiently
- new tests added for variant setting
- new tests added to confirm proper version setting
- type UUID now conforms to the BinaryMarshaller and BinaryUnmarshaller interfaces
- New was added to create a base UUID from a []byte
- ParseHex was renamed to simply Parse
- Parse creates a UUID and properly checks the string format
- NewHex now performs unsafe creation of UUID from a hex string
- NewV3 and NewV5 now take strings as a namespace name
