### PR TITLE
Optimize String method

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -11,7 +11,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"hash"
 	"regexp"
 )
@@ -169,5 +168,18 @@ func (u *UUID) Version() uint {
 
 // Returns unparsed version of the generated UUID sequence.
 func (u *UUID) String() string {
-	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
+	const s byte = '-'
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], u[0:4])
+	buf[8] = s
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = s
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = s
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = s
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -6,6 +6,7 @@
 package uuid
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 )
@@ -122,6 +123,12 @@ func TestNewV5(t *testing.T) {
 	}
 }
 
+func TestString(t *testing.T) {
+	if NamespaceDNS.String() != "6ba7b810-9dad-11d1-80b4-00c04fd430c8" {
+		t.Error("Expected String returns unparsed version of UUID")
+	}
+}
+
 func BenchmarkParseHex(b *testing.B) {
 	s := "f3593cff-ee92-40df-4086-87825b523f13"
 	for i := 0; i < b.N; i++ {
@@ -129,6 +136,22 @@ func BenchmarkParseHex(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+	}
+	b.StopTimer()
+	b.ReportAllocs()
+}
+
+func BenchmarkStringNew(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = NamespaceDNS.String()
+	}
+	b.StopTimer()
+	b.ReportAllocs()
+}
+
+func BenchmarkStringOld(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = fmt.Sprintf("%x-%x-%x-%x-%x", NamespaceDNS[0:4], NamespaceDNS[4:6], NamespaceDNS[6:8], NamespaceDNS[8:10], NamespaceDNS[10:])
 	}
 	b.StopTimer()
 	b.ReportAllocs()


### PR DESCRIPTION
New String() method is approximately 14 times faster

Benchmarks:

```
BenchmarkStringNew  20000000           121 ns/op          48 B/op          1 allocs/op
BenchmarkStringOld   1000000          1709 ns/op         269 B/op          9 allocs/op
```
