### PR TITLE
Make the lib a bit more user friendly (methods on value)

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -1,4 +1,4 @@
-// This package provides immutable UUID structs and the functions
+// Package uuid provides immutable UUID structs and the functions
 // NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
 // and 5 UUIDs as specified in RFC 4122.
 //
@@ -16,7 +16,7 @@ import (
 	"regexp"
 )
 
-// The UUID reserved variants. 
+// The UUID reserved variants.
 const (
 	ReservedNCS       byte = 0x80
 	ReservedRFC4122   byte = 0x40
@@ -41,7 +41,7 @@ const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-" +
 
 var re = regexp.MustCompile(hexPattern)
 
-// A UUID representation compliant with specification in
+// UUID is an UUID representation compliant with specification in
 // RFC 4122 document.
 type UUID [16]byte
 
@@ -80,8 +80,8 @@ func Parse(b []byte) (u *UUID, err error) {
 	return
 }
 
-// Generate a UUID based on the MD5 hash of a namespace identifier
-// and a name.
+// NewV3 generates a UUID based on the MD5 hash of a namespace
+// identifier and a name.
 func NewV3(ns *UUID, name []byte) (u *UUID, err error) {
 	if ns == nil {
 		err = errors.New("Invalid namespace UUID")
@@ -95,7 +95,7 @@ func NewV3(ns *UUID, name []byte) (u *UUID, err error) {
 	return
 }
 
-// Generate a random UUID.
+// NewV4 generates a random UUID.
 func NewV4() (u *UUID, err error) {
 	u = new(UUID)
 	// Set all bits to randomly (or pseudo-randomly) chosen values.
@@ -108,8 +108,8 @@ func NewV4() (u *UUID, err error) {
 	return
 }
 
-// Generate a UUID based on the SHA-1 hash of a namespace identifier
-// and a name.
+// NewV5 generates a UUID based on the SHA-1 hash of a namespace
+// identifier and a name.
 func NewV5(ns *UUID, name []byte) (u *UUID, err error) {
 	u = new(UUID)
 	// Set all bits to truncated SHA1 hash generated from namespace
@@ -167,7 +167,7 @@ func (u *UUID) Version() uint {
 	return uint(u[6] >> 4)
 }
 
-// Returns unparsed version of the generated UUID sequence.
+// String returns unparsed version of the generated UUID sequence.
 func (u *UUID) String() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
 }

--- a/uuid.go
+++ b/uuid.go
@@ -144,7 +144,7 @@ func (u *UUID) setVariant(v byte) {
 // Variant returns the UUID Variant, which determines the internal
 // layout of the UUID. This will be one of the constants: RESERVED_NCS,
 // RFC_4122, RESERVED_MICROSOFT, RESERVED_FUTURE.
-func (u *UUID) Variant() byte {
+func (u UUID) Variant() byte {
 	if u[8]&ReservedNCS == ReservedNCS {
 		return ReservedNCS
 	} else if u[8]&ReservedRFC4122 == ReservedRFC4122 {
@@ -163,11 +163,11 @@ func (u *UUID) setVersion(v byte) {
 
 // Version returns a version number of the algorithm used to
 // generate the UUID sequence.
-func (u *UUID) Version() uint {
+func (u UUID) Version() uint {
 	return uint(u[6] >> 4)
 }
 
 // String returns unparsed version of the generated UUID sequence.
-func (u *UUID) String() string {
+func (u UUID) String() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
 }


### PR DESCRIPTION
- for the maintainer: fixes git lint warnings (about function's comments)
- for the user: stop forcing `Variant()`, `Version()` and `String()` to be called on pointers

The second commit (62f4d0c7b0891be66882636a7c09dc19e7487484) is more interesting: because these methods are defines on pointer, is it currently not possible to call them against a simple `UUID` value, even if nothing prevent to do so.
