### PR TITLE
Changed HEX pattern.

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -36,8 +36,8 @@ var (
 // FIXME: do something to consider both brackets at one time,
 // current one allows to parse string with only one opening
 // or closing bracket.
-const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-" +
-	"([1-5][a-z0-9]{3})-([a-z0-9]{4})-([a-z0-9]{12})\\}?$"
+const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-f0-9]{8})-([a-f0-9]{4})-" +
+	"([1-5][a-f0-9]{3})-([a-f0-9]{4})-([a-f0-9]{12})\\}?$"
 
 var re = regexp.MustCompile(hexPattern)
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-const format = "^[a-z0-9]{8}-[a-z0-9]{4}-[1-5][a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12}$"
+const format = "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}$"
 
 func TestParse(t *testing.T) {
 	_, err := Parse([]byte{1, 2, 3, 4, 5})


### PR DESCRIPTION
According to RFC and valid HEX characters, I suggest changing the word characters range to `a-f` only. Otherwise your previous pattern will match string like `zzzzzzzz-zzzz-1zzz-zzzz-zzzzzzzzzzzz` which is not a valid UUID.
