### PR TITLE
Json marshal as string

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -54,18 +54,23 @@ type UUID [16]byte
 //     uuid.ParseHex("urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8")
 //
 func ParseHex(s string) (u *UUID, err error) {
+	b, err := parseHex(s)
+	if err != nil {
+		return
+	}
+	u = new(UUID)
+	copy(u[:], b)
+	return
+}
+
+func parseHex(s string) (b []byte, err error) {
 	md := re.FindStringSubmatch(s)
 	if md == nil {
 		err = errors.New("Invalid UUID string")
 		return
 	}
 	hash := md[2] + md[3] + md[4] + md[5] + md[6]
-	b, err := hex.DecodeString(hash)
-	if err != nil {
-		return
-	}
-	u = new(UUID)
-	copy(u[:], b)
+	b, err = hex.DecodeString(hash)
 	return
 }
 
@@ -191,10 +196,10 @@ func (u *UUID) UnmarshalJSON(b []byte) error {
 	if len(s) < 2 {
 		return errors.New("Invalid UUID string")
 	}
-	v, err := ParseHex(s[1 : len(s)-1])
+	b, err := parseHex(s[1 : len(s)-1])
 	if err != nil {
 		return err
 	}
-	copy(u[:], v[:])
+	copy(u[:], b)
 	return nil
 }

--- a/uuid.go
+++ b/uuid.go
@@ -171,3 +171,30 @@ func (u *UUID) Version() uint {
 func (u *UUID) String() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
 }
+
+// MarshalJSON implements the json.Marshaler interface.
+// The UUID is a quoted string in 8-4-4-4-12 format.
+func (u *UUID) MarshalJSON() ([]byte, error) {
+	v := []byte(u.String())
+	b := make([]byte, 0, len(v)+2)
+	b = append(b, '"')
+	b = append(b, v...)
+	b = append(b, '"')
+	return b, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// The UUID is expected to be a quoted string in a format supported by ParseHex.
+func (u *UUID) UnmarshalJSON(b []byte) error {
+	s := string(b)
+	// Guard against a short slice, allow ParseHex to deal with everything else.
+	if len(s) < 2 {
+		return errors.New("Invalid UUID string")
+	}
+	v, err := ParseHex(s[1 : len(s)-1])
+	if err != nil {
+		return err
+	}
+	copy(u[:], v[:])
+	return nil
+}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -6,6 +6,8 @@
 package uuid
 
 import (
+	"encoding/json"
+	"fmt"
 	"regexp"
 	"testing"
 )
@@ -119,6 +121,39 @@ func TestNewV5(t *testing.T) {
 	u4, _ := NewV5(NamespaceURL, []byte("code.google.com"))
 	if u4.String() == u.String() {
 		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	u, err := NewV4()
+	if err != nil {
+		t.Errorf("Expected to generate UUID without problems, error thrown: %d", err.Error())
+		return
+	}
+	b, err := json.Marshal(u)
+	if err != nil {
+		t.Errorf("Expected no problem marshaling UUID")
+	}
+	re := regexp.MustCompile(fmt.Sprintf("^\"%s\"$", format[1:len(format)-1]))
+	if !re.MatchString(string(b)) {
+		t.Errorf("Expected JSON representation to be valid, given %s", string(b))
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	b := []byte("\"42c4d4c2-baa5-4e24-47d6-cf50b3cb8c3f\"")
+	u := new(UUID)
+	err := json.Unmarshal(b, u)
+	if err != nil {
+		t.Errorf("Expected to unmarshal well formed UUID json: %v", err)
+	}
+	if u.String() != string(b[1:len(b)-1]) {
+		t.Errorf("Expected unmarshaled UUID and input to be the same")
+	}
+
+	err = json.Unmarshal([]byte("0"), u)
+	if err == nil {
+		t.Errorf("Expected error due to unmarshaling a short slice")
 	}
 }
 


### PR DESCRIPTION
I've implemented json.Marshaler / Unmarshaler to serialize UUIDs to quoted strings.

The first commit implements the features, the second is a refactor touching ParseHex to avoid an unnecessary allocation in the Unmarshal path.
